### PR TITLE
feat: add herdr config with vim-style keybindings

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,13 @@
+onboarding = false
+
+[keys]
+prefix = "ctrl+g"
+settings = ""
+reload_config = "prefix+shift+r"
+copy_mode = "prefix+["
+focus_pane_left = "prefix+h"
+focus_pane_down = "prefix+j"
+focus_pane_up = "prefix+k"
+focus_pane_right = "prefix+l"
+split_vertical = "prefix+v"
+split_horizontal = "prefix+s"


### PR DESCRIPTION
## Summary

- `ctrl+g` をprefixとしたherdrのキーバインド設定を追加
- Vim風の `hjkl` でペインフォーカス移動
- `prefix+v` / `prefix+s` で垂直・水平分割

## Test plan

- [ ] herdr を起動し `ctrl+g` でprefixが動作することを確認
- [ ] `prefix+hjkl` でペイン移動が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)